### PR TITLE
Job for deleting vehciles after 2 hour

### DIFF
--- a/app/Jobs/DeleteExpiredParkingAssignmentsJob.php
+++ b/app/Jobs/DeleteExpiredParkingAssignmentsJob.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\ParkingAssignment;
+use Carbon\Carbon;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+
+class DeleteExpiredParkingAssignmentsJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public function __construct() {}
+
+    public function handle(): void
+    {
+
+        $deletedRecords = ParkingAssignment::where('expires_at', '<=', Carbon::now())->delete();
+
+        ParkingAssignment::where('expires_at', '<=', Carbon::now())->delete();
+
+        logger()->info("Deleted {$deletedRecords} expired parking assignments.");
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Middleware\HandleInertiaRequests;
+use App\Jobs\DeleteExpiredParkingAssignmentsJob;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
@@ -15,6 +16,9 @@ return Application::configure(basePath: dirname(__DIR__))
         $middleware->web(append: [
             HandleInertiaRequests::class,
         ]);
+    })
+    ->withSchedule(function ($schedule) {
+        $schedule->job(new DeleteExpiredParkingAssignmentsJob)->everyTwoHours();
     })
     ->withExceptions(function (Exceptions $exceptions) {
         //


### PR DESCRIPTION
This pull request introduces a new job to delete expired parking assignments and schedules it to run every two hours. The most important changes include the creation of the job class, its inclusion in the application bootstrap file, and the scheduling configuration.

### New Job Creation:

* [`app/Jobs/DeleteExpiredParkingAssignmentsJob.php`](diffhunk://#diff-f2caa5d32ca5074498374ed2aad034ec0ef44a40edd83a7a7fb435905b72e6e3R1-R28): Created a new job class `DeleteExpiredParkingAssignmentsJob` that deletes expired parking assignments from the database and logs the number of deleted records.

### Application Bootstrap Modifications:

* [`bootstrap/app.php`](diffhunk://#diff-10bc2462d34ebc59a5d482a1faca04ce74f6df89fcc2ef8bfb17b939647ea518R4): Added the `DeleteExpiredParkingAssignmentsJob` to the application imports.
* [`bootstrap/app.php`](diffhunk://#diff-10bc2462d34ebc59a5d482a1faca04ce74f6df89fcc2ef8bfb17b939647ea518R20-R22): Configured the application to schedule the `DeleteExpiredParkingAssignmentsJob` to run every two hours.